### PR TITLE
moved the required version of elixir down to 1.5

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule MixUnder.MixProject do
     [
       app: :mix_under,
       version: "0.1.1",
-      elixir: "~> 1.6",
+      elixir: "~> 1.5",
       start_permanent: Mix.env() == :prod,
       description: "Run mix tasks (like test or ecto db.migrate) under specific umbrella applications",
       deps: deps(),


### PR DESCRIPTION
We are currently locked on elixir 1.5 and from our testing mix under works fine.  Love the library, so useful in testing umbrella apps!